### PR TITLE
fixes to LAUREN room

### DIFF
--- a/external/lauren/index.html
+++ b/external/lauren/index.html
@@ -12,7 +12,7 @@
   <meta property="og:description" content="LAUREN is a human intelligent smart home. Lauren will visit your home, deploy a series of smart devices, and watch over you remotely 24/7. Lauren will control your home for you, attempting to be better than an AI, understanding you as a person. You will be able to interact with her by calling her name, but she will also do things for you without your asking. She will learn faster than an algorithm, adapting to your desires and anticipating your needs." />
   <meta property="og:image" content="/lauren/images/LAUREN3.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:creator" content="@laurmccarthy" />
+  <meta name="twitter:creator" content="@laurenleemack" />
 
   <meta aframe-injected='' name='viewport' content='width=device-width,initial-scale=1,maximum-scale=1,shrink-to-fit=no,user-scalable=no'>
   <meta aframe-injected='' name='mobile-web-app-capable' content='yes'>
@@ -25,10 +25,6 @@
 
   <!-- other libraries -->
   <script src='https://code.jquery.com/jquery-3.2.1.min.js' integrity='sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=' crossorigin='anonymous'></script>
-  <script src="https://player.vimeo.com/api/player.js"></script>
-  <script src="https://cdn.webrtc-experiment.com/gumadapter.js"></script>
-  <script src="/lauren/js/RecordRTC.min.js"></script>
-  <script src='/lauren/js/s3upload.js'></script>
 
   <!-- aframe and components -->
   <script src="https://aframe.io/releases/1.0.4/aframe.min.js"></script>
@@ -46,11 +42,6 @@
 </head>
 
 <body class='a-body' id='container'>
-
-  <iframe src="https://player.vimeo.com/video/397068136/" width="640" height="320" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay"></iframe>
-
-  <img src='/lauren/media/volume-on.png' id='volume' class='button'>
-  <!-- <img src='img/restart.png' id='reload' class='button'> -->
 
   <nav>
     <span id='learnmore' class='button'>LEARN MORE</span>
@@ -133,7 +124,7 @@
   </div>
 
 
-  <a-scene class='fullscreen' canvas keyboard-shortcuts screenshot vr-mode-ui='enabled: false'>
+  <a-scene class='fullscreen' canvas keyboard-shortcuts screenshot vr-mode-ui='enabled: false' device-orientation-permission-ui='enabled: false'>
     <a-assets timeout='5000'>
       <video id='lauren-video' crossorigin='anonymous' src='/lauren/media/lauren-broll4.mp4' autoplay loop='true' muted></video>
       <video id='lauren-listening' crossorigin='anonymous' src='/lauren/media/lauren-listening4.mp4' autoplay loop='true' muted></video>

--- a/external/lauren/js/set-image.js
+++ b/external/lauren/js/set-image.js
@@ -22,7 +22,6 @@ AFRAME.registerComponent('set-image', {
 
     el.addEventListener(data.on, function () {
       homeOpen = true;
-      player.pause();
       data.target.setAttribute('src', data.src);
       data.target.emit('stopRotateSky');
       data.target.emit('startRotateHome');

--- a/external/lauren/js/site.js
+++ b/external/lauren/js/site.js
@@ -2,7 +2,6 @@ var plate = 0; // 1 - learnmore, 2 - getlauren
 var h;
 var videoPlaying = false;
 var videoEnded = false;
-var player;
 var videoLoaded = false;
 var sceneSetup = false;
 var dotInterval;
@@ -37,7 +36,6 @@ function closeHome(force) {
   currentHome.emit('close');
   $('#closeHome').hide();
   if (!force) toggleHomes(true);
-  if (videoPlaying && !hideVideo) player.play();
   homeOpen = false;
 }
 
@@ -56,7 +54,6 @@ function getLauren(val) {
       resetForm();
     }
   } else {
-    if (videoPlaying && !hideVideo) player.play();
     var opac = videoPlaying ? 0 : 1;
     sky.setAttribute('material', 'shader: flat; src: #lauren-video; opacity:'+opac);
     sky.emit('startRotateSky');
@@ -175,18 +172,6 @@ $(document).ready(function() {
     }
   });
 
-  $('#volume').click(function() {
-    if ($(this).attr('src') === 'img/volume-on.png') {
-      $(this).attr('src', 'img/volume-off.png');
-      player.setVolume(0);
-    } else {
-      $(this).attr('src', 'img/volume-on.png');
-      player.setVolume(1);
-    }
-  });
-  $('#reload').click(function() {
-    window.location.reload();
-  });
 
   $('#learnmore').click(function() {
     if (plate == 1) {
@@ -261,52 +246,21 @@ $(document).ready(function() {
     resizeDOM();
   });
 
-  // VIMEO STUFF
-  var iframe = document.querySelector('iframe');
-  player = new Vimeo.Player(iframe);
 
-
-  player.on('loaded', function() {
-    videoLoaded = true;
-    if (sceneSetup) {
-      setTimeout(function() {
-        $('#loading').html('Press to Enter');
-      }, 3000);
-    }
-  });
-
+  videoLoaded = true;
+  if (sceneSetup) {
+    setTimeout(function() {
+      $('#loading').html('Press to Enter');
+    }, 3000);
+  }
   // ENTER!
   $('#js-lauren-hall').click(function() {
     $('#js-lauren-hall').hide();
     $('#loading').hide();
     clearInterval(dotInterval); 
-    if (videoPlaying && !hideVideo) player.play();
     $('#lauren-video')[0].play();
     startPassthrough();
   })
-
-  if (!hideVideo) {
-    player.addCuePoint(9, {type: 'show'});
-    player.addCuePoint(221, {type: 'end'});
-    player.on('cuepoint', function(e) {
-      if (e.data.type === 'show') {
-        document.querySelector('#image-360').emit('hide360');
-        document.querySelector('#links').emit('lower');
-      }
-      else if (e.data.type === 'end') {
-        videoPlaying = false;
-        videoEnded = true;
-        //player.pause();
-        document.querySelector('#image-360').emit('show360');
-        document.querySelector('#links').emit('raise');
-        console.log('ended the video!');
-      }
-    });
-    $(document).click(function() {
-      if (!videoPlaying && !videoEnded) player.play();
-      videoPlaying = true;
-    });
-  }
 
   resizeDOM();
 

--- a/src/index.html
+++ b/src/index.html
@@ -75,7 +75,7 @@
 
             <footer class="attribution">
                 <p>Curated by Behnaz Farahi.</p>
-                <p>Design and development by Julian Ceipek, Lauren McCarthy, Behnaz Farahi. </p>
+                <p>Design and development by Julian Ceipek, Lauren Lee McCarthy, Behnaz Farahi. </p>
                 <p>Includes icons by Vectors Market.</p>
                 <p>&copy; 2020</p>
             </footer>


### PR DESCRIPTION
1. We can still can enter to your hall before the loading sign is finished. Or somehow it let us in before properly loading all the assets in your hall. Therefore, sometimes the hall shows a blue page and sometimes looks a bit broken. Is there any way to fix this by making sure the viewer cant get in before all the assets are loaded? **Fixed**

2. Could you please move the two icons (sound and return) from top to bottom of your page? Currently, the sound icon is hidden underneath the navigation icons.  **Fixed. Remove icons completely, they seem unnecessary in this context.**

3. Remove HTTP popup error. I've tried to set things so this won't appear, but I can't test very well until it's integrated into the main site. If we still see it occur, it would be best to just serve the site over HTTPS only (better for security anyway). You're already doing this with your URL, so you would just need to setup a redirect to force HTTP to HTTPS.

![image](https://user-images.githubusercontent.com/191056/89474070-683a9980-d739-11ea-8210-9d58fc130bc6.png)
